### PR TITLE
Added space to environment variables delimiter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "null_resource" "provisioner" {
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} ${var.playbook} -e ${join("-e", var.envs)}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} ${var.playbook} -e ${join(" -e ", var.envs)}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "null_resource" "provisioner" {
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} ${var.playbook} -e ${join(" -e ", var.envs)}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)}" ${var.playbook}
   }
 
   lifecycle {


### PR DESCRIPTION
## What
* Added space to environment variables delimiter

## Why
* Function `join` joins a list without space between  delimiter

## Plan
![image](https://user-images.githubusercontent.com/1134449/29724658-f7b71e02-89d1-11e7-93b6-cf72d13968f4.png)


