### PR TITLE
Use `null_resource` trigger in order to detect `ansible-playbook` command changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default   = "${sha256(file(var.playbook))}"
+    default   = "${sha256(dirname(var.playbook))}"
     signature = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,18 @@
+data "null_data_source" "ansible" {
+  inputs = {
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
+  }
+}
+
 resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default = "${sha256(file(var.playbook))}"
+    default = "${data.null_data_source.ansible.command}"
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
+    command = "${data.null_data_source.ansible.command}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,13 @@
-resource "null_resource" "ansible" {
-  triggers = {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
-  }
-}
-
 resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
     default = "${sha256(file(var.playbook))}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
   }
 
   provisioner "local-exec" {
-    command = "${null_resource.ansible.triggers.command}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
-data "null_data_source" "ansible" {
-  inputs = {
+resource "null_resource" "ansible" {
+  triggers = {
     command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
   }
 }
@@ -8,11 +8,11 @@ resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default = "${data.null_data_source.ansible.inputs.command}"
+    default = "${null_resource.ansible.triggers.command}"
   }
 
   provisioner "local-exec" {
-    command = "${data.null_data_source.ansible.inputs.command}"
+    command = "${null_resource.ansible.triggers.command}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@ resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default = "${sha256(file(var.playbook))}"
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
+    default   = "${sha256(file(var.playbook))}"
+    signature = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,11 @@ resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default = "${data.null_data_source.ansible.command}"
+    default = "${data.null_data_source.ansible.inputs.command}"
   }
 
   provisioner "local-exec" {
-    command = "${data.null_data_source.ansible.command}"
+    command = "${data.null_data_source.ansible.inputs.command}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default = "${null_resource.ansible.triggers.command}"
+    default = "${sha256(file(var.playbook))}"
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,8 @@ resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
   triggers {
-    default   = "${sha256(dirname(var.playbook))}"
-    signature = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
+    signature = "${sha256(dirname(var.playbook))}"
+    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## What
* Reworked code of module to generate a trigger from the argument signature of the command

## Why
* Ansible provisioner module doesn't recognize changes when its options are changed